### PR TITLE
Add ability to disable auto pip mode

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'cl.puntito.simple_pip_mode'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -46,5 +46,7 @@ android {
 }
 
 dependencies {
+    implementation "androidx.core:core:1.10.1"
+    implementation 'androidx.annotation:annotation:1.7.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/src/main/kotlin/cl/puntito/simple_pip_mode/SimplePipModePlugin.kt
+++ b/android/src/main/kotlin/cl/puntito/simple_pip_mode/SimplePipModePlugin.kt
@@ -131,10 +131,11 @@ class SimplePipModePlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     } else if (call.method == "setAutoPipMode") {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         val aspectRatio = call.argument<List<Int>>("aspectRatio")
+        val autoEnter = call.argument<Boolean>("autoEnter")
         val seamlessResize = call.argument<Boolean>("seamlessResize")
         val params = PictureInPictureParams.Builder()
           .setAspectRatio(Rational(aspectRatio!![0], aspectRatio[1]))
-          .setAutoEnterEnabled(true)
+          .setAutoEnterEnabled(autoEnter!!)
           .setSeamlessResizeEnabled(seamlessResize!!)
           .setActions(actions)
 

--- a/android/src/main/kotlin/cl/puntito/simple_pip_mode/SimplePipModePlugin.kt
+++ b/android/src/main/kotlin/cl/puntito/simple_pip_mode/SimplePipModePlugin.kt
@@ -12,6 +12,8 @@ import android.os.Build
 import android.util.Rational
 import androidx.annotation.NonNull
 import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.RECEIVER_EXPORTED
 import cl.puntito.simple_pip_mode.Constants.EXTRA_ACTION_TYPE
 import cl.puntito.simple_pip_mode.Constants.SIMPLE_PIP_ACTION
 import cl.puntito.simple_pip_mode.actions.PipAction
@@ -62,7 +64,8 @@ class SimplePipModePlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         }
       }
     }.also { broadcastReceiver = it }
-    context.registerReceiver(broadcastReceiver, IntentFilter(SIMPLE_PIP_ACTION))
+
+    ContextCompat.registerReceiver(context, broadcastReceiver, IntentFilter(SIMPLE_PIP_ACTION), RECEIVER_EXPORTED)
   }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
@@ -76,7 +79,7 @@ class SimplePipModePlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       result.success("Android ${Build.VERSION.RELEASE}")
     } else if (call.method == "isPipAvailable") {
       result.success(
-        activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+              activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
       )
     } else if (call.method == "isPipActivated") {
       result.success(activity.isInPictureInPictureMode)
@@ -87,18 +90,18 @@ class SimplePipModePlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       val autoEnter = call.argument<Boolean>("autoEnter")
       val seamlessResize = call.argument<Boolean>("seamlessResize")
       var params = PictureInPictureParams.Builder()
-        .setAspectRatio(Rational(aspectRatio!![0], aspectRatio[1]))
-        .setActions(actions)
+              .setAspectRatio(Rational(aspectRatio!![0], aspectRatio[1]))
+              .setActions(actions)
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         params = params.setAutoEnterEnabled(autoEnter!!)
-          .setSeamlessResizeEnabled(seamlessResize!!)
+                .setSeamlessResizeEnabled(seamlessResize!!)
       }
 
       this.params = params
 
       result.success(
-        activity.enterPictureInPictureMode(params.build())
+              activity.enterPictureInPictureMode(params.build())
       )
     } else if (call.method == "setPipLayout") {
       val success = call.argument<String>("layout")?.let {
@@ -114,7 +117,7 @@ class SimplePipModePlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     } else if (call.method == "setIsPlaying") {
       call.argument<Boolean>("isPlaying")?.let { isPlaying ->
         if (actionsLayout.actions.contains(PipAction.PLAY) ||
-          actionsLayout.actions.contains(PipAction.PAUSE)) {
+                actionsLayout.actions.contains(PipAction.PAUSE)) {
           var i = actionsLayout.actions.indexOf(PipAction.PLAY)
           if (i == -1) {
             i = actionsLayout.actions.indexOf(PipAction.PAUSE)

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/lib/simple_pip.dart
+++ b/lib/simple_pip.dart
@@ -60,11 +60,12 @@ class SimplePip {
   /// Android 12 (Android S, API level 31) or newer required.
   Future<bool> setAutoPipMode({
     aspectRatio = const [16, 9],
+    autoEnter = true,
     seamlessResize = false,
   }) async {
     Map params = {
       'aspectRatio': aspectRatio,
-      'autoEnter': true,
+      'autoEnter': autoEnter,
       'seamlessResize': seamlessResize,
     };
     final bool? setSuccessfully =


### PR DESCRIPTION
First of all, thank you for the awesome package! Best implementation of PiP for Flutter/Android I've seen so far.

One issue I came across was there isn't a way to globally disable `autoEnter` (`setAutoEnterEnabled`). This meant that once I called `setAutoPipMode`, auto PiP would be enabled for the rest of the app's lifetime. As a result, the **entire app** goes into PiP mode from any screen when leaving the app.

In this PR, I've simply modified `setAutoPipMode` to allow the `autoEnter` parameter to be passed, just like how it is in `enterPipMode`. May not be the best solution, but it was the first one I could think of.