### PR TITLE
Android 14 support (RECEIVER_NOT_EXPORTED)

### DIFF
--- a/android/src/main/kotlin/cl/puntito/simple_pip_mode/SimplePipModePlugin.kt
+++ b/android/src/main/kotlin/cl/puntito/simple_pip_mode/SimplePipModePlugin.kt
@@ -62,7 +62,7 @@ class SimplePipModePlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         }
       }
     }.also { broadcastReceiver = it }
-    context.registerReceiver(broadcastReceiver, IntentFilter(SIMPLE_PIP_ACTION))
+    context.registerReceiver(broadcastReceiver, IntentFilter(SIMPLE_PIP_ACTION), 4) // 4=RECEIVER_NOT_EXPORTED
   }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {


### PR DESCRIPTION
Optionally one could import ContextCompat and use the constant from there.